### PR TITLE
Dont assume organism

### DIFF
--- a/includes/tripal_apollo.node.inc
+++ b/includes/tripal_apollo.node.inc
@@ -83,10 +83,21 @@ function apollo_instance_form($node, &$form_state) {
 
   $form['core']['url'] = [
     '#type' => 'textfield',
-    '#title' => t("URL of Apollo server"),
+    '#title' => t("URL of Apollo Server"),
     '#required' => TRUE,
     '#default_value' => isset($node->url) ? $node->url : '',
 
+  ];
+
+
+  $table_choices = ['organism' => 'Organism', 'Analysis' => 'Analysis', 'project '=> 'Project'];
+
+  $form['core']['base_table'] = [
+    '#type' => 'select',
+    '#options' => $table_choices,
+    '#title' => t("Chado Base Table"),
+    '#description' => 'Each record can only be associated with one instance.  We suggest associating instances with organisms.  However, if you would like to support different assemblies for the same organism, you can use the chado project or analysis table instead.',
+    '#default_value' => isset($node->base_table) ? $node->base_table : 'organism',
   ];
 
   $select = [1 => 'Apollo 1', 2 => 'Apollo 2'];

--- a/includes/tripal_apollo.node.inc
+++ b/includes/tripal_apollo.node.inc
@@ -90,7 +90,7 @@ function apollo_instance_form($node, &$form_state) {
   ];
 
 
-  $table_choices = ['organism' => 'Organism', 'Analysis' => 'Analysis', 'project '=> 'Project'];
+  $table_choices = ['organism' => 'Organism', 'analysis' => 'Analysis', 'project '=> 'Project'];
 
   $form['core']['base_table'] = [
     '#type' => 'select',
@@ -172,8 +172,6 @@ function apollo_instance_insert($node) {
 
   $password = drupal_hash_base64($node->admin_password);
 
-  dpm($node);
-
   db_insert('apollo_instance')->fields([
     'nid' => $node->nid,
     'name' => $node->instance_name,
@@ -181,6 +179,7 @@ function apollo_instance_insert($node) {
     'apollo_version' => $node->apollo_version,
     'admin_name' => $node->admin_name,
     'admin_password' => $password,
+    'base_table' => $node->base_table
   ])->execute();
 
 }
@@ -198,6 +197,7 @@ function apollo_instance_update($node) {
     'url' => $node->url,
     'apollo_version' => $node->apollo_version,
     'admin_name' => $node->admin_name,
+    'base_table' => $node->base_table
   ];
 
 
@@ -239,7 +239,7 @@ function apollo_instance_load($nodes) {
     $nodes[$record->nid]->instance_name = $record->name;
     $nodes[$record->nid]->url = $record->url;
     $nodes[$record->nid]->apollo_version = $record->apollo_version;
-
+    $nodes[$record->nid]->base_table = $record->base_table;
   }
 
   return $nodes;
@@ -250,7 +250,7 @@ function apollo_instance_load($nodes) {
  * This function acts on ALL NODES
  */
 function tripal_apollo_node_insert($node) {
-  if ($node->type == 'web_apollo') {
+  if ($node->type == 'apollo_instance') {
     $node->title = $node->instance_name;
   }
 }
@@ -260,7 +260,7 @@ function tripal_apollo_node_insert($node) {
  * This function acts on ALL NODES
  */
 function tripal_apollo_node_update($node) {
-  if ($node->type == 'web_apollo') {
+  if ($node->type == 'apollo_instance') {
     $node->title = $node->instance_name;
   }
 }

--- a/includes/tripal_apollo_approve_user_request.form.inc
+++ b/includes/tripal_apollo_approve_user_request.form.inc
@@ -44,11 +44,12 @@ function tripal_apollo_approve_user_request_form($form, &$form_state, $uid) {
   ];
 
   //Look up instance for this organism
+  //TODO: support non-organism base tables.
 
-  $query = db_select('apollo_instance_organism', 'aio');
+  $query = db_select('apollo_instance_record', 'aio');
   $query->join('apollo_instance', 'ai', 'ai.id  = aio.instance_id');
   $query->addField('ai', 'name');
-  $query->condition('aio.organism_id', $organism_object->organism_id);
+  $query->condition('aio.record_id', $organism_object->organism_id);
   $instance_name = $query->execute()
     ->fetchField();
 

--- a/tripal_apollo.install
+++ b/tripal_apollo.install
@@ -51,7 +51,7 @@ function tripal_apollo_schema() {
       'base_table' => [
         'type' => 'varchar',
         'length' => 64,
-        'description' => 'The chado base table this instance is associated with.  It could be organism'
+        'description' => 'The chado base table this instance is associated with.  It could be organism, project, or analysis.'
       ]
     ],
     'unique keys' => [

--- a/tripal_apollo.install
+++ b/tripal_apollo.install
@@ -48,6 +48,11 @@ function tripal_apollo_schema() {
         'size' => 'small'
         //1 or 2
       ],
+      'base_table' => [
+        'type' => 'varchar',
+        'length' => 64,
+        'description' => 'The chado base table this instance is associated with.  It could be organism'
+      ]
     ],
     'unique keys' => [
       'URL' => ['URL'],
@@ -172,8 +177,8 @@ function tripal_apollo_uninstall() {
 
 function tripal_apollo_add_instance_user_organism_schemas($schema) {
 
-  $schema['apollo_instance_organism'] = [
-    'description' => "Simple linker table to associate organisms with apollo instances.",
+  $schema['apollo_instance_record'] = [
+    'description' => "Simple linker table to associate chado records with apollo instances.",
     'fields' => [
       'id' => [
         'type' => 'serial',
@@ -186,28 +191,28 @@ function tripal_apollo_add_instance_user_organism_schemas($schema) {
         'not null' => TRUE,
         'description' => "Apollo instance id, as specified in apollo_instance",
       ],
-      'organism_id' => [
+      'record_id' => [
         'type' => 'int',
         'not null' => TRUE,
-        'description' => "Chado organism record ID.",
+        'description' => "Chado primary record ID for the corresponding instance base table.",
       ],
     ],
     'unique keys' => [
-      'apollo_instance_organism_uq1' => ['instance_id'],
+      'apollo_instance_record_uq1' => ['record_id'],
     ],
     'primary key' => ['id'],
   ];
 
 
-  $schema['apollo_user_organism_instance'] = [
-    'description' => 'links web apollo user IDs to organisms.  A user can have access to multiple (but not all) organisms on a given instance.  An organism may also be found on multiple instances.',
+  $schema['apollo_user_record_instance'] = [
+    'description' => 'links web apollo user IDs to chado records.  A user can have access to multiple (but not all) records on a given instance.  A record may only be found on one instances.',
     'fields' => [
       'id' => [
         'type' => 'serial',
         'unsigned' => TRUE,
         'not null' => TRUE,
       ],
-      'organism_id' => [
+      'record_id' => [
         'type' => 'int',
         'description' => 'chado organism.organism_id',
         'not null' => TRUE,
@@ -216,7 +221,6 @@ function tripal_apollo_add_instance_user_organism_schemas($schema) {
         'type' => 'int',
         'description' => "apollo_instance.id",
         'not null' => TRUE,
-
       ],
       'apollo_user_id' => [
         'type' => 'int',


### PR DESCRIPTION
adds support for non-organism base tables for instance connection.  
Requires a 1:1 instance:record.

Not included:

updating the UI to check against other record types.  Specifically in the request forms and the admin area where the organism name is built.