### PR TITLE
Switch schema

### DIFF
--- a/includes/tripal_apollo.node.inc
+++ b/includes/tripal_apollo.node.inc
@@ -328,8 +328,6 @@ function apollo_instance_load($nodes) {
 function tripal_apollo_node_insert($node) {
   if ($node->type == 'apollo_instance') {
     $node->title = $node->instance_name;
-
-    dpm($node);
   }
 }
 

--- a/includes/tripal_apollo_api.inc
+++ b/includes/tripal_apollo_api.inc
@@ -28,3 +28,50 @@ function tripal_apollo_gen_xkcd_password($num_of_words = 1) {
   }
   return $password;
 }
+
+/**
+ * Fetches all records associated with an Apollo instance.
+ */
+function tripal_apollo_get_elligible_records() {
+
+  $base = variable_get('tripal_apollo_base_table');
+  $base_key = $base . '_id';
+
+  $records = db_select('apollo_instance_record', 'tair')
+    ->fields('tair', ['record_id'])
+    ->execute();
+
+  $out = [];
+
+  foreach ($records as $record) {
+    $record_id = $record->record_id;
+    switch ($base) {
+      case 'organism':
+
+        $result = chado_select_record($base, [
+          'genus',
+          'species',
+        ], [$base_key => $record_id]);
+
+        $result = $result[0];
+
+        $out[$record_id] = $result->genus . ' ' . $result->species;
+        break;
+      /**
+       * By default we can just use name.
+       */
+      case 'default':
+        $chado_record = chado_select_record($base, [
+          'name',
+        ], [$base_key => $record_id]);
+        $result = chado_select_record($base, [$base_key => $record_id]);
+        $result = $result[0];
+        $out[$record_id] = $result->name;
+        break;
+    }
+
+
+  }
+
+  return $out;
+}

--- a/includes/tripal_apollo_approve_user_request.form.inc
+++ b/includes/tripal_apollo_approve_user_request.form.inc
@@ -11,13 +11,13 @@ function tripal_apollo_approve_user_request_form($form, &$form_state, $submissio
 
   $header = [];
 
-  //note: UID is not user id.  uid is the webapollo_users.id
-  $data = db_select('webapollo_users', 'w')
-    ->fields('w', ['uid', 'name', 'pass', 'email', 'organisms', 'status'])
-    ->condition('w.uid', $submission_id, '=')
-    ->execute()->fetchObject();
+  $query = db_select('apollo_user_record', 'aur')
+    ->fields('aur', ['record_id', 'status'])
+    ->condition('aur.id', $submission_id);
+  $query->join('apollo_user', 'au');
+  $query->fields('au', ['name', 'pass', 'email', 'institution', 'comment']);
+  $data = $query->execute()->fetchObject();
 
-  //TODO: on schema update, include the base table.
 
   $form['web_apollo_table'] = [
     '#tree' => TRUE, // Need this for easy submit processing
@@ -36,16 +36,14 @@ function tripal_apollo_approve_user_request_form($form, &$form_state, $submissio
   ];
 
 
-  //it says organisms here but in reality it will be only a single organism since we retrieved one record only.
-
   //todo: genercize to be any content type.
-  $organism_object = chado_get_organism(['organism_id' => $data->organisms]);
+  $organism_object = chado_get_organism(['organism_id' => $data->record_id]);
 
   $organism_value = $organism_object->abbreviation . ' (' . $organism_object->common_name . ')';
 
   $form['web_apollo_table']['organism_key'] = [
     '#type' => 'value',
-    '#value' => $data->organisms,
+    '#value' => $data->record_id,
   ];
 
   $form['web_apollo_table']['organism'] = [
@@ -95,9 +93,10 @@ function tripal_apollo_approve_user_request_form($form, &$form_state, $submissio
     '#options' => [t('Reject'), t('Approve')],
   ];
 
+  //TODO:  this is not the drupal uid.  Rename the value (here and in theme file)
   $form['web_apollo_table']['uid'] = [
     '#type' => 'value',
-    '#value' => $data->uid,
+    '#value' => $data->id,
   ];
 
   $form['web_apollo_table']['pass'] = [
@@ -116,9 +115,8 @@ function tripal_apollo_approve_user_request_form($form, &$form_state, $submissio
 
 }
 
-
 /**
- * @hook_form_submit()
+ * Implements hook_form_submit().
  * Runs the add_user.pl and set_track_permissions.pl to create user accounts
  *   and permissions for respective organisms.
  *
@@ -129,13 +127,13 @@ function tripal_apollo_approve_user_request_form_submit($form, &$form_state) {
   $values = $form_state['values']['web_apollo_table'];
   $values['type'] = 1;
   $status = $form_state['values']['web_apollo_table']['status'];//reject or approve
-  $uid = $form_state['values']['web_apollo_table']['uid'];
+  $submission_id = $form_state['values']['web_apollo_table']['uid'];
   //TODO: not actually uid.  this is the submission id
   $to = $values['email'];
   $from = variable_get('site_mail');
-  $status_res = db_select('webapollo_users', 'w')
-    ->fields('w', ['status'])
-    ->condition('w.uid', $uid, '=')
+  $status_res = db_select('apollo_user_record', 'aur')
+    ->fields('aur', ['status'])
+    ->condition('aur.id', $submission_id)
     ->execute()->fetchField();
 
   $instance_id = $form_state['values']['instance_id'];
@@ -151,7 +149,6 @@ function tripal_apollo_approve_user_request_form_submit($form, &$form_state) {
 
   if (($status_res != $status) && ($status == 1)) {//User is approved.
 
-
     $host = $instance_info->url;
     $db_name = $instance_info->database_name;
     $db_user = $instance_info->admin_name;
@@ -159,68 +156,18 @@ function tripal_apollo_approve_user_request_form_submit($form, &$form_state) {
 
     $db_pass = $instance_info->admin_password;
 
-    /****
-     * The goal is to make the password same for all organism for same emailid.
-     * First check for the email already registered for any organism with status=1, if yes then take the most recent password and update in webapollo_users and apollo tables.
-     * IF not then check for email with status=2, then take most recent password and update in webapollo_uses and apollo tables.
-     */
-
-    //TODO:  we will replace this with the new schema.
     $email = $to;
-    $check_email_status1_exists = db_select('webapollo_users', 'w')
-      ->fields('w', ['uid', 'name', 'pass', 'organisms'])
-      ->condition('w.email', $email, '=')
-      ->condition('w.status', 1, '=')
-      ->orderby('w.created', 'desc')
-      ->range(0, 1)
-      ->execute()->fetchObject();
-
-    $check_email_status2_exists = db_select('webapollo_users', 'w')
-      ->fields('w', ['uid', 'name', 'pass', 'organisms'])
-      ->condition('w.email', $email, '=')
-      ->condition('w.status', 2, '=')
-      ->orderby('w.created', 'desc')
-      ->range(0, 1)
-      ->execute()->fetchObject();
-
 
     $user = $values['email']; //Note: same as $to and $email.
+    $user_pass = $values['pass'];
 
-    if (isset($check_email_status1_exists) && !empty($check_email_status1_exists)) {
-      //user has an apollo 1 record: update THIS entry's password.
-      $pass = $check_email_status1_exists->pass;
-      db_update('webapollo_users')
-        ->fields(['pass' => $pass])
-        ->condition('uid', $uid, '=')
-        ->execute();
-
-    }
-    elseif (isset($check_email_status2_exists) && !empty($check_email_status2_exists)) {
-      //user has an apollo 2 record: update THIS entry's password with it.
-
-      $pass = $check_email_status2_exists->pass;
-      db_update('webapollo_users')
-        ->fields(['pass' => $pass])
-        ->condition('uid', $uid, '=')
-        ->execute();
-    }
-    else {
-      $pass = $values['pass'];
-    }
-
-    // If the values['pass'] should be the updated password from recent password.
-    if ($values['pass'] != $pass) {
-      $values['pass'] = $pass;
-    }
-
-    //TODO: get this from sitewide variable in admin area
     $python_path = variable_get('tripal_apollo_python_path');
     $script_path = drupal_get_path('module', 'tripal_apollo') . '/bin/adduser.py';
 
     //TODO:  drupal best practices running scripts?
     //TODO: get python path via admin setting.
 
-    $exec_user = exec($python_path . " " . $script_path . " -dbuser " . $db_user . " -dbname " . $db_name . " -user " . $user . " -pwd " . $pass . " -host " . $host);
+    $exec_user = exec($python_path . " " . $script_path . " -dbuser " . $db_user . " -dbname " . $db_name . " -user " . $user . " -pwd " . $user_pass . " -host " . $host);
 
 
     //TODO:  sounds like apollo 1 support feature-level permissions.  How do we suppor this?
@@ -246,9 +193,9 @@ function tripal_apollo_approve_user_request_form_submit($form, &$form_state) {
       drupal_set_message(t('Failed to send the email due to some technical problems'));
     }
     else {
-      db_update('webapollo_users')// Table name no longer needs {}
-      ->fields(['status' => $status])
-        ->condition('uid', $uid, '=')
+      db_update('apollo_user_record')
+        ->fields(['status' => $status])
+        ->condition('id', $submission_id)
         ->execute();
       drupal_set_message(t('Successfully an email was sent to %email regarding the status approved.', ['%email' => $values['email']]), $type = 'status');
     }
@@ -262,9 +209,9 @@ function tripal_apollo_approve_user_request_form_submit($form, &$form_state) {
   } // Status approved condition ends here
 
   elseif ($status == 0) {
-    db_update('webapollo_users')
+    db_update('apollo_user_record')
       ->fields(['status' => $status])
-      ->condition('uid', $uid, '=')
+      ->condition('id', $submission_id)
       ->execute();
     drupal_set_message(t('The apollo request for %name has been successfuly rejected.', ['%name' => $values['name']]), $type = 'status');
   }

--- a/includes/tripal_apollo_approve_user_request.form.inc
+++ b/includes/tripal_apollo_approve_user_request.form.inc
@@ -14,7 +14,7 @@ function tripal_apollo_approve_user_request_form($form, &$form_state, $submissio
   $query = db_select('apollo_user_record', 'aur')
     ->fields('aur', ['record_id', 'status'])
     ->condition('aur.id', $submission_id);
-  $query->join('apollo_user', 'au');
+  $query->join('apollo_user', 'au', 'aur.apollo_user_id = au.id');
   $query->fields('au', ['name', 'pass', 'email', 'institution', 'comment']);
   $data = $query->execute()->fetchObject();
 
@@ -36,28 +36,32 @@ function tripal_apollo_approve_user_request_form($form, &$form_state, $submissio
   ];
 
 
-  //todo: genercize to be any content type.
-  $organism_object = chado_get_organism(['organism_id' => $data->record_id]);
+  if (variable_get('tripal_apollo_base_table') == 'organism') {
+    $pkey = "organism_id";
+    $record_object = chado_get_organism(['organism_id' => $data->record_id]);
 
-  $organism_value = $organism_object->abbreviation . ' (' . $organism_object->common_name . ')';
+    $organism_value = $record_object->abbreviation . ' (' . $record_object->common_name . ')';
 
-  $form['web_apollo_table']['organism_key'] = [
-    '#type' => 'value',
-    '#value' => $data->record_id,
-  ];
+    $form['web_apollo_table']['organism_key'] = [
+      '#type' => 'value',
+      '#value' => $data->record_id,
+    ];
 
-  $form['web_apollo_table']['organism'] = [
-    '#type' => 'value',
-    '#value' => $organism_value,
-  ];
+    $form['web_apollo_table']['organism'] = [
+      '#type' => 'value',
+      '#value' => $organism_value,
+    ];
+  }
+  else {
+    //todo: genercize to be any content type.
+  }
 
-  //Look up instance for this organism
-  //TODO: support non-organism base tables.
+  //Look up instance for this record
 
   $query = db_select('apollo_instance_record', 'aio');
   $query->join('apollo_instance', 'ai', 'ai.id  = aio.instance_id');
   $query->fields('ai', ['name', 'id']);
-  $query->condition('aio.record_id', $organism_object->organism_id);
+  $query->condition('aio.record_id', $record_object->$pkey);
   $result = $query->execute()
     ->fetchObject();
 
@@ -94,9 +98,10 @@ function tripal_apollo_approve_user_request_form($form, &$form_state, $submissio
   ];
 
   //TODO:  this is not the drupal uid.  Rename the value (here and in theme file)
+
   $form['web_apollo_table']['uid'] = [
     '#type' => 'value',
-    '#value' => $data->id,
+    '#value' => $submission_id,
   ];
 
   $form['web_apollo_table']['pass'] = [
@@ -136,7 +141,8 @@ function tripal_apollo_approve_user_request_form_submit($form, &$form_state) {
     ->condition('aur.id', $submission_id)
     ->execute()->fetchField();
 
-  $instance_id = $form_state['values']['instance_id'];
+  //$instance_id = $form_state['values']['instance_id'];
+
   $record_id = $values['organism_key'];
 
   $query = db_select('apollo_instance_record', 'air')

--- a/includes/tripal_apollo_registration.form.inc
+++ b/includes/tripal_apollo_registration.form.inc
@@ -1,16 +1,67 @@
 <?php
 
-//TODO:  I would prefer to make this all happen in Vanilla drupal upon standard user account creation.
-
-
 /**
  *  hook_form() registration form for the web apollo
  */
 function tripal_apollo_registration_form($form, &$form_state) {
 
+
   $form['instructions'] = [
-    '#markup' => '<div id=\"tripal_apollo_param\">Complete the form below and click \'Submit\' to register for an Apollo account.  Only registered users can view, create or change annotations.</div>'
+    '#markup' => '<div id=\"tripal_apollo_param\">Complete the form below and click \'Submit\' to register for an Apollo account.  Only registered users can view, create or change annotations.</div>',
   ];
+
+  $organisms = chado_get_organism_select_options(FALSE);
+
+  unset($organisms[0]);
+
+  //remove records user is already associated with.
+
+  global $user;
+
+  $associated_records = [];
+  //if we're logged in, remove the records already associated.
+  if ($user->uid > 0) {
+
+    $form['uid'] = [
+      '#type' => 'value',
+      '#value' => $user->uid,
+    ];
+
+    $query = db_select('apollo_user_record', 'aur')
+      ->fields('aur', ['record_id'])
+      ->join('apollo_user', 'au', 'auri.apollo_user_id = au.id');
+    $query->condition('au.uid', $user->uid);
+
+    $results = $query->execute->fetchAll();
+
+
+    foreach ($results as $result) {
+      $record_id = $result->record_id;
+      unset($organisms[$record_id]);
+
+      $record = chado_get_organism(['organism_id' => $record_id]);
+
+
+      $associated_records[] = implode(' ', [$record->genus, $record->species]);
+    }
+
+    if (!empty($associated_records)) {
+      $message = 'You have already requested access to the following records:<ul>';
+
+      foreach ($associated_records as $label) {
+        $message .= '<li> ' . $label . '</li>';
+      }
+      $message .= '</ul>';
+
+      $form['existing'] = [
+        '#type' => 'markup',
+        '#markup' => $message,
+      ];
+    }
+
+  }
+
+
   $form['name'] = [
     '#type' => 'textfield',
     '#title' => t('Full Name'),
@@ -26,12 +77,6 @@ function tripal_apollo_registration_form($form, &$form_state) {
     '#description' => 'The email address you will use to log in to the Apollo server.',
     '#default_value' => NULL,
   ];
-
-  //TODO: functionality could allow you to associate organisms with web apollo if necessary?  Otherwise, just all chado organisms.
-
-  $organisms = chado_get_organism_select_options(FALSE);
-
-  unset($organisms[0]);
 
   $form['organism'] = [
     '#type' => 'select',
@@ -63,6 +108,8 @@ function tripal_apollo_registration_form($form, &$form_state) {
 }
 
 /**
+ * Implements hook_validate().
+ *
  * Web apollo registration form validation
  * 1 - organism field is required
  * 2 - Email should be valid
@@ -85,25 +132,22 @@ function tripal_apollo_registration_form_validate($form, &$form_state) {
   $organisms = $form_state['values']['organism'];
   $email = $form_state['values']['mail'];
 
-  //Check if this email is already associated with this organism.
+  //Check if this user is already associated with this organism.
 
-  $results = db_select('webapollo_users', 'w')
-    ->fields('w', ['uid', 'organisms'])
-    ->condition('w.email', $email)
-    ->condition('w.organisms', $organisms, 'IN')
-    ->execute()
+  $query = db_select('apollo_user_record', 'aur');
+  $query->join('apollo_user', 'au');
+  $query->fields('aur', ['id'])
+    ->condition('au.email', $email)
+    ->condition('aur.record_id', $organisms, 'IN');
+
+  $results = $query->execute()
     ->fetchAll();
-
-  $cnt = 0;
 
   if ($results) {
     $message = "You are already registered for the following organisms: ";
 
     foreach ($results as $key => $result) {
-
-      //TODO: Previous entries store a special organism/genus key instead of organism_id currently.
-      //see @ticket 11
-      $organism = chado_get_organism(['organism_id' => $result->organisms]);
+      $organism = chado_get_organism(['organism_id' => $result->record_id]);
       $message .= $organism->abbreviation . ", ";
     }
     form_set_error('organism', $message);
@@ -111,82 +155,77 @@ function tripal_apollo_registration_form_validate($form, &$form_state) {
   }
 }
 
+/**
+ * Implements hook_submit().
+ * Creates requests for each selected record for the user.
+ * Notifies user and admin via email.
+ */
 function tripal_apollo_registration_form_submit($form, &$form_state) {
   $admin_email = variable_get('site_mail');
   $values = $form_state['values'];
 
-  /****
-   * The goal is to make the password same for all organism for a given email.
-   * First check for the email already registered for any organism with status=1, if yes then take the most recent password.
-   * IF not then check for email with status=2, then take most recent password and update in webapollo_users table.
-   */
-
-  //TODO:  Switching to a different schema would be really helpful here.
-
+  //Is there a user record?
   $email = $values['mail'];
-  $check_email_status1_exists = db_select('webapollo_users', 'w')
-    ->fields('w', ['uid', 'name', 'pass', 'organisms'])
-    ->condition('w.email', $email, '=')
-    ->condition('w.status', 1, '=')
-    ->orderby('w.created', 'desc')
-    ->range(0, 1)
-    ->execute()->fetchObject();
+  $uid = isset($values['uid']) ? $values['uid'] : NULL;
 
-  $check_email_status2_exists = db_select('webapollo_users', 'w')
-    ->fields('w', ['uid', 'name', 'pass', 'organisms'])
-    ->condition('w.email', $email, '=')
-    ->condition('w.status', 2, '=')
-    ->orderby('w.created', 'desc')
-    ->range(0, 1)
-    ->execute()->fetchObject();
+  $query = db_select('apollo_user', 'au')
+    ->fields('au', ['uid', 'pass', 'email', 'id'])
+    ->condition('au.email', $email);
+  $result = $query->execute()->fetchObject();
 
-  if (isset($check_email_status1_exists) && !empty($check_email_status1_exists)) {
-    $pass = $check_email_status1_exists->pass;;
-  }
-  elseif (isset($check_email_status2_exists) && !empty($check_email_status2_exists)) {
-    $pass = $check_email_status2_exists->pass;
+  //If not, create password and user record
+
+  if ($result) {
+    $password = $result->pass;
+    $au_id = $result->id;
+
   }
   else {
-    $pass = tripal_apollo_gen_xkcd_password(2);
+    $password = tripal_apollo_gen_xkcd_password(2);
+    $au_id = db_insert('apollo_user')
+      ->fields([
+        'uid' => $uid,
+        'name' => $values['name'],
+        'pass' => $password,
+        'email' => $email,
+        'institution' => $values['institution'],
+        'comment' => $values['comments'],
+        'create' => time(),
+      ])
+      ->execute();
+  }
+  //write link with status 0
+  foreach ($values['organism'] as $record_id => $organism_val) {
+
+    drupal_write_record('apollo_user_record', [
+
+      'record_id' => $record_id,
+      'apollo_user_id' => $au_id,
+      'status' => 0 //pending request
+    ]);
   }
 
-  $created = time();
-
-  foreach ($values['organism'] as $key => $organism_val) {
-    $data = [
-      'name' => $values['name'],
-      'pass' => $pass,
-      'email' => $values['mail'],
-      'organisms' => $organism_val,
-      'institution' => $values['institution'],
-      'comment' => $values['comments'],
-      'created' => $created,
-    ];
-    drupal_write_record('webapollo_users', $data);
-  }
-
-  // E-mail address of the sender: as the form field is a text field.
+  //send emails
   $from = $values['name'] . "<" . $values['mail'] . ">";
-
-  // Send the e-mail to the recipients using the site default language.
   $sent = drupal_mail('tripal_apollo', 'notify_admin_organism_request', $admin_email, language_default(), $values, $from, TRUE);
+
 
   if (empty($sent['result']) || ($sent['result'] != 1)) {
     /*handle send fail, $sent ===false when mail fails, but it won't always recognize a failure*/
-    drupal_set_message(t('Failed to send e-mail.'));
+    drupal_set_message(t('Error: Failed to send e-mail notification.'));
   }
   else {
-    drupal_set_message(t('Your message has been sent. You will receive an email confirmation shortly.'));
+    drupal_set_message(t('Thank you for requesting Apollo access. You will receive an email confirmation shortly.'));
   }
 
   //Email to the registered user stating successfully registered and once approved from admin you can login to the site
   $user_email_sent = drupal_mail('tripal_apollo', 'notify_user_organism_request', $values['mail'], language_default(), $values, $admin_email, TRUE);
 
   if (empty($user_email_sent['result']) || ($user_email_sent['result'] != 1)) {
-    drupal_set_message(t('Failed to send the email due to some technical problems'));
+    drupal_set_message(t('Error: Failed to send e-mail notification.'));
+
   }
 
-  // Jump to home page rather than back to web apollo registration page to avoid
-  // contradictory messages if flood control has been activated.
+  //return to homepage
   $form_state['redirect'] = variable_get('site_frontpage');
 }

--- a/includes/tripal_apollo_registration.form.inc
+++ b/includes/tripal_apollo_registration.form.inc
@@ -47,12 +47,10 @@ function tripal_apollo_registration_form($form, &$form_state) {
 
     if (!empty($associated_records)) {
       $message = 'You have already requested access to the following records:<ul>';
-
       foreach ($associated_records as $label) {
         $message .= '<li> ' . $label . '</li>';
       }
       $message .= '</ul>';
-
       $form['existing'] = [
         '#type' => 'markup',
         '#markup' => $message,
@@ -190,7 +188,6 @@ function tripal_apollo_registration_form_submit($form, &$form_state) {
         'email' => $email,
         'institution' => $values['institution'],
         'comment' => $values['comments'],
-        'create' => time(),
       ])
       ->execute();
   }
@@ -201,7 +198,9 @@ function tripal_apollo_registration_form_submit($form, &$form_state) {
 
       'record_id' => $record_id,
       'apollo_user_id' => $au_id,
-      'status' => 0 //pending request
+      'status' => 2,//pending request
+      'create' => time(),
+
     ]);
   }
 

--- a/includes/tripal_apollo_registration.form.inc
+++ b/includes/tripal_apollo_registration.form.inc
@@ -5,48 +5,67 @@
  */
 function tripal_apollo_registration_form($form, &$form_state) {
 
-
   $form['instructions'] = [
     '#markup' => '<div id=\"tripal_apollo_param\">Complete the form below and click \'Submit\' to register for an Apollo account.  Only registered users can view, create or change annotations.</div>',
   ];
 
-  $organisms = chado_get_organism_select_options(FALSE);
 
-  unset($organisms[0]);
+  $choices = tripal_apollo_get_elligible_records();
+  if (!$choices) {
+    $form['instructionsp2'] = [
+      '#markup' => '<p>Apollo configuration is still underway.  <p>Please contact a site administrator</p></p></div>',
+    ];
+    return $form;
+  }
 
-  //remove records user is already associated with.
+  //remove records user is already associated with, and the prebuilt null selection.
 
   global $user;
 
   $associated_records = [];
   //if we're logged in, remove the records already associated.
-  if ($user->uid > 0) {
 
+  if ($user->uid > 0) {
     $form['uid'] = [
       '#type' => 'value',
       '#value' => $user->uid,
     ];
 
     $query = db_select('apollo_user_record', 'aur')
-      ->fields('aur', ['record_id'])
-      ->join('apollo_user', 'au', 'auri.apollo_user_id = au.id');
+      ->fields('aur', ['record_id']);
+    $query->join('apollo_user', 'au', 'aur.apollo_user_id = au.id');
     $query->condition('au.uid', $user->uid);
 
-    $results = $query->execute->fetchAll();
+    $results = $query->execute()->fetchAll();
 
+    $base = variable_get('tripal_apollo_base_table');
+    $pkey = $base . '_id';
 
     foreach ($results as $result) {
       $record_id = $result->record_id;
-      unset($organisms[$record_id]);
-
-      $record = chado_get_organism(['organism_id' => $record_id]);
+      unset($choices[$record_id]);
 
 
-      $associated_records[] = implode(' ', [$record->genus, $record->species]);
+      if ($base == 'organism') {
+        $chado_record = chado_select_record($base, [
+          'genus',
+          'species',
+        ], [$pkey => $record_id]);
+        $chado_record = $chado_record[0];
+
+        $label = $chado_record->genus . ' ' . $chado_record->species;
+      }
+      else {
+        $chado_record = chado_select_record($base, ['name'], [$pkey => $record_id]);
+        $chado_record = $chado_record[0];
+        $label = $chado_record->name;
+
+      }
+      $associated_records[] = $label;
     }
 
     if (!empty($associated_records)) {
-      $message = 'You have already requested access to the following records:<ul>';
+      $message = 'You have already requested access to the following  '.  $base. 's :<ul>';
       foreach ($associated_records as $label) {
         $message .= '<li> ' . $label . '</li>';
       }
@@ -56,9 +75,7 @@ function tripal_apollo_registration_form($form, &$form_state) {
         '#markup' => $message,
       ];
     }
-
   }
-
 
   $form['name'] = [
     '#type' => 'textfield',
@@ -76,14 +93,15 @@ function tripal_apollo_registration_form($form, &$form_state) {
     '#default_value' => NULL,
   ];
 
+
   $form['organism'] = [
     '#type' => 'select',
-    '#title' => t('Organism'),
-    '#options' => $organisms,
+    '#title' => t('Apollo Content'),
+    '#options' => $choices,
     '#multiple' => TRUE,
     '#required' => TRUE,
-    '#empty_option' => "Please select an Organism",
-    '#description' => 'The organisms you would like access to.',
+    '#empty_option' => "Please select",
+    '#description' => 'The ' . $base . '  you would like access to.',
   ];
 
   $form['institution'] = [
@@ -133,7 +151,7 @@ function tripal_apollo_registration_form_validate($form, &$form_state) {
   //Check if this user is already associated with this organism.
 
   $query = db_select('apollo_user_record', 'aur');
-  $query->join('apollo_user', 'au');
+  $query->join('apollo_user', 'au', 'au.id = aur.apollo_user_id');
   $query->fields('aur', ['id'])
     ->condition('au.email', $email)
     ->condition('aur.record_id', $organisms, 'IN');
@@ -191,17 +209,18 @@ function tripal_apollo_registration_form_submit($form, &$form_state) {
       ])
       ->execute();
   }
-  //write link with status 0
+  //  //write link with status 0
   foreach ($values['organism'] as $record_id => $organism_val) {
 
-    drupal_write_record('apollo_user_record', [
+    db_insert('apollo_user_record')
+      ->fields([
+        'record_id' => $record_id,
+        'apollo_user_id' => $au_id,
+        'status' => 2,//pending request
+        'created' => time(),
+      ])
+      ->execute();
 
-      'record_id' => $record_id,
-      'apollo_user_id' => $au_id,
-      'status' => 2,//pending request
-      'create' => time(),
-
-    ]);
   }
 
   //send emails
@@ -228,3 +247,4 @@ function tripal_apollo_registration_form_submit($form, &$form_state) {
   //return to homepage
   $form_state['redirect'] = variable_get('site_frontpage');
 }
+

--- a/includes/tripal_apollo_requests.form.inc
+++ b/includes/tripal_apollo_requests.form.inc
@@ -52,11 +52,12 @@ function tripal_apollo_user_table() {
   $query = db_select("apollo_user_record", "aur");
 
   $query->fields('aur', [
+    'id',
     'record_id',
     'status',
-    'created',
-    'id',
+    'created'
   ]);
+  $query->join('apollo_instance_record', 'air', 'air.record_id = aur.record_id');
 
   $query->fields('air', [
     'instance_id',
@@ -66,8 +67,9 @@ function tripal_apollo_user_table() {
   $query->fields('au', ['name', 'email']);
   $query->orderBy($order, $sort);
   $query = $query->extend('TableSort')->extend('PagerDefault')->limit(25);
-
   $result = $query->execute();
+
+
   $header = [
     ["data" => t('Name'), "field" => "name"],
     ["data" => t('Email'), "field" => "email"],
@@ -81,11 +83,12 @@ function tripal_apollo_user_table() {
   $rows = [];
   $i = 0;
 
+
   // Looping for filling the table rows
   while ($data = $result->fetchObject()) {
-
     //convert organism_id to organism name
     //TODO:  support multiple base tables
+
     $organism = chado_get_organism(['organism_id' => $data->record_id]);
 
     $organism_string = $organism->genus . ' ' . $organism->species;
@@ -120,7 +123,7 @@ function tripal_apollo_user_table() {
         // Table header will be sticky
         "caption" => "",
         "colgroups" => [],
-        "empty" => t("Table has no row!")
+        "empty" => t("There are no Apollo registration requests.")
         // The message to be displayed if table is empty
       ]
     ) . theme("pager");

--- a/includes/tripal_apollo_requests.form.inc
+++ b/includes/tripal_apollo_requests.form.inc
@@ -6,11 +6,8 @@
  */
 function tripal_apollo_requests_form($form, &$form_state) {
   $user_info = tripal_apollo_user_table();
-
   $form['users'] = ['#markup' => $user_info];
-
   return $form;
-
 }
 
 /**
@@ -28,7 +25,6 @@ function tripal_apollo_user_table() {
     else {
       $sort = 'DESC';
     }
-
     // Which column will be sorted
     switch ($_GET['order']) {
       case 'Name':
@@ -37,8 +33,8 @@ function tripal_apollo_user_table() {
       case 'Email':
         $order = 'email';
         break;
-      case 'Organism':
-        $order = 'organisms';
+      case 'Record':
+        $order = 'record_id';
         break;
       case 'Status':
         $order = 'status';
@@ -53,15 +49,21 @@ function tripal_apollo_user_table() {
     $order = 'created';
   }
 
-  $query = db_select("webapollo_users", "w");
-  $query->fields("w", [
-    "uid",
-    "name",
-    "email",
-    "organisms",
-    "status",
-    "created",
+  $query = db_select("apollo_user_record", "aur");
+
+  $query->fields('aur', [
+    'record_id',
+    'status',
+    'created',
+    'id',
   ]);
+
+  $query->fields('air', [
+    'instance_id',
+    'record_id',
+  ]);
+  $query->join('apollo_user', 'au', 'au.id = aur.apollo_user_id');
+  $query->fields('au', ['name', 'email']);
   $query->orderBy($order, $sort);
   $query = $query->extend('TableSort')->extend('PagerDefault')->limit(25);
 
@@ -69,7 +71,7 @@ function tripal_apollo_user_table() {
   $header = [
     ["data" => t('Name'), "field" => "name"],
     ["data" => t('Email'), "field" => "email"],
-    ["data" => t('Organism'), "field" => "Organisms"],
+    ["data" => t('Record'), "field" => "record_id"],
     ["data" => t('Status'), "field" => "status"],
     ["data" => t('Created'), "field" => "created", 'sort' => 'desc'],
     [],
@@ -83,8 +85,8 @@ function tripal_apollo_user_table() {
   while ($data = $result->fetchObject()) {
 
     //convert organism_id to organism name
-
-    $organism = chado_get_organism(['organism_id' => $data->organisms]);
+    //TODO:  support multiple base tables
+    $organism = chado_get_organism(['organism_id' => $data->record_id]);
 
     $organism_string = $organism->genus . ' ' . $organism->species;
 
@@ -104,7 +106,7 @@ function tripal_apollo_user_table() {
     }
     $rows[$i][] = $status;
     $rows[$i][] = date('M d Y h:i:s A', $data->created);
-    $rows[$i][] = l(t('Edit'), 'admin/tripal/apollo/users/' . $data->uid);
+    $rows[$i][] = l(t('Edit'), 'admin/tripal/apollo/users/' . $data->id);
     $i++;
   }
 
@@ -124,17 +126,4 @@ function tripal_apollo_user_table() {
     ) . theme("pager");
 
   return $output;
-}
-
-
-/**
- * Search key by value from an array
- **/
-function searchkey($organism_data, $needle) {
-  foreach ($organism_data as $key => $data) {
-    if (strcmp($key, $needle) == 0) {
-      return $key;
-    }
-  }
-  return FALSE;
 }

--- a/tripal_apollo.install
+++ b/tripal_apollo.install
@@ -13,6 +13,7 @@
 function tripal_apollo_install() {
   //the python variable is set by the admin but we set the default here.
   variable_set('tripal_apollo_python_path', "/usr/local/bin/python2.7");
+  variable_set('tripal_apollo_base_table', "organism");
 
 }
 

--- a/tripal_apollo.install
+++ b/tripal_apollo.install
@@ -229,6 +229,7 @@ function tripal_apollo_add_instance_user_organism_schemas($schema) {
         'not null' => TRUE,
         'description' => "Chado primary record ID for the corresponding instance base table.",
       ],
+      //TODO:  move to site variable.
       'base_table' => [
         'type' => 'varchar',
         'length' => 64,
@@ -263,9 +264,15 @@ function tripal_apollo_add_instance_user_organism_schemas($schema) {
       'status' => [
         'type' => 'int',
         'not null' => TRUE,
-        'default' => 0,
+        'default' => 2,
         'size' => 'tiny',
-        'description' => "Request status.  0 = pending, 1 = approved, 2 = denied",
+        'description' => "Request status.  0 = rejected, 1 = approved, 2 = pending",
+      ],
+      'created' => [
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'Timestamp for when user was created.',
       ],
     ],
     'primary_key' => ['id'],
@@ -320,12 +327,6 @@ function tripal_apollo_add_instance_user_organism_schemas($schema) {
         'size' => 'big',
         'not null' => FALSE,
         'description' => 'The comment body.',
-      ],
-      'created' => [
-        'type' => 'int',
-        'not null' => TRUE,
-        'default' => 0,
-        'description' => 'Timestamp for when user was created.',
       ],
     ],
     'primary key' => ['id'],

--- a/tripal_apollo.install
+++ b/tripal_apollo.install
@@ -9,7 +9,9 @@
 /**
  * Implements hook_install().
  */
+
 function tripal_apollo_install() {
+  //the python variable is set by the admin but we set the default here.
   variable_set('tripal_apollo_python_path', "/usr/local/bin/python2.7");
 
 }
@@ -41,27 +43,27 @@ function tripal_apollo_schema() {
         'type' => 'varchar',
         'length' => 64,
         'not null' => TRUE,
-        'description' => 'Descriptive name for the instance.'
+        'description' => 'Descriptive name for the instance.',
       ],
       'database_name' => [
         'not null' => TRUE,
         'type' => 'varchar',
         'length' => 64,
-        'description' => 'Database name on the Apollo instance.'
+        'description' => 'Database name on the Apollo instance.',
 
       ],
       'admin_name' => [
         'not null' => TRUE,
         'type' => 'varchar',
         'length' => 64,
-        'description' => 'Database admin username on the Apollo instance.'
+        'description' => 'Database admin username on the Apollo instance.',
 
       ],
       'admin_password' => [
         'not null' => TRUE,
         'type' => 'varchar',
         'length' => 64,
-        'description' => "Database admin password on the Apollo instance"
+        'description' => "Database admin password on the Apollo instance",
       ],
       'apollo_version' => [
         'type' => 'int',
@@ -240,7 +242,7 @@ function tripal_apollo_add_instance_user_organism_schemas($schema) {
   ];
 
 
-  $schema['apollo_user_record_instance'] = [
+  $schema['apollo_user_record'] = [
     'description' => 'links web apollo user IDs to chado records.  A user can have access to multiple (but not all) records on a given instance.  A record may only be found on one instances.',
     'fields' => [
       'id' => [
@@ -253,18 +255,23 @@ function tripal_apollo_add_instance_user_organism_schemas($schema) {
         'description' => 'chado organism.organism_id',
         'not null' => TRUE,
       ],
-      'instance_id' => [
-        'type' => 'int',
-        'description' => "apollo_instance.id",
-        'not null' => TRUE,
-      ],
       'apollo_user_id' => [
         'type' => 'int',
         'description' => 'apollo_user.id',
         'not null' => TRUE,
       ],
+      'status' => [
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+        'size' => 'tiny',
+        'description' => "Request status.  0 = pending, 1 = approved, 2 = denied",
+      ],
     ],
     'primary_key' => ['id'],
+    'unique keys' => [
+      'apollo_user_record_u1' => ['record_id', 'apollo_user_id'],
+    ],
   ];
 
   $schema['apollo_user'] = [
@@ -277,7 +284,7 @@ function tripal_apollo_add_instance_user_organism_schemas($schema) {
       ],
       'uid' => [
         'type' => 'int',
-        'not null' => TRUE,
+        //nullable to support sites who want to allow registration-free requests
         'description' => 'Drupal user ID',
       ],
       'name' => [
@@ -322,6 +329,11 @@ function tripal_apollo_add_instance_user_organism_schemas($schema) {
       ],
     ],
     'primary key' => ['id'],
+    'unique keys' => [
+      'email' => ['email'],
+      'uid' => ['uid'],
+
+    ],
   ];
   return $schema;
 }

--- a/tripal_apollo.module
+++ b/tripal_apollo.module
@@ -3,6 +3,7 @@
 require_once 'includes/tripal_apollo_api.inc';
 require_once 'includes/tripal_apollo.node.inc';
 require_once 'includes/tripal_apollo_mail.inc';
+require_once 'includes/tripal_apollo.api.inc';
 
 //forms dont need to be
 //require_once 'includes/tripal_apollo_admin.form.inc';

--- a/tripal_apollo.module
+++ b/tripal_apollo.module
@@ -62,8 +62,6 @@ function tripal_apollo_menu() {
     'page callback' => 'drupal_get_form',
     'page arguments' => ['tripal_apollo_registration_form'],
     'access arguments' => ['access apollo'],
-    'type' => MENU_CALLBACK,
-    'weight' => 100,
     'file' => 'includes/tripal_apollo_registration.form.inc',
   ];
 
@@ -96,13 +94,12 @@ function tripal_apollo_menu() {
     'file' => 'includes/tripal_apollo_admin_form.inc',
   ];
 
-
   return $items;
 }
 
-
 /**
  * Theme for the user approval page.
+ *
  * @param $variables
  *
  * @return string


### PR DESCRIPTION
this PR totally revamps all db access to the new schema.

Some points:

* we still support anonymous uses.  If that changes, the schema can get neater.  If not, thats fine too.  We just make drupal UID optional.
* users can supply additional email/names if they want: it just gets associated with a new apollo_user record.  We could drop support for this, but this would only be wise if we also drop anonymous user support.
* we've moved base table out of the schema into a site-wide variable.  The node neesd to be updated accordingly.