### PR TITLE
110 reject user

### DIFF
--- a/includes/tripal_apollo_api.inc
+++ b/includes/tripal_apollo_api.inc
@@ -645,6 +645,7 @@ function tripal_apollo_rescind_user_permissions($submission_id, $instance_id) {
   $groups = [$base . '_USER', $base . '_WRITE'];
   $instance = tripal_apollo_get_instance($instance_id);
 
+
   if ($instance->apollo_version == 1) {
     tripal_set_message(t("Cannot change group permissions for Apollo 1 instance: !name", ['!name' => $instance->name]), TRIPAL_WARNING);
     return FALSE;

--- a/includes/tripal_apollo_approve_user_request.form.inc
+++ b/includes/tripal_apollo_approve_user_request.form.inc
@@ -106,7 +106,7 @@ function tripal_apollo_approve_user_request_form($form, &$form_state, $submissio
   //dont allow reject if already approved for Apollo 1.
 
 
-  if ($instance_info->version == 1 && $data->status == 1){
+  if ($instance_info->apollo_version == 1 && $data->status == 1){
 
     $options = [t('Approve')];
   }
@@ -174,6 +174,7 @@ function tripal_apollo_approve_user_request_form_submit($form, &$form_state) {
   //one record = one instance, so only 1 result
   $instance_info = $query->execute()->fetchObject();
 
+
   if (($status_res != $status) && ($status == 1)) {//User is approved.
 
     //execute python scripts
@@ -201,32 +202,31 @@ function tripal_apollo_approve_user_request_form_submit($form, &$form_state) {
     ]), $type = 'status');
   } // Status approved condition ends here
 
-  elseif ($status == 0) {
+  elseif ($status == 0 && $status_res ==1) {
 
-    $prev_status = db_select('apollo_user_record', 't')
-    ->fields('t', ['status' => $status])
-      ->condition('id', $submission_id)
-      ->execute();
-
-    if (!$prev_status == 1){
       //We are rejecting a previously accepted user.  Remove their permissions.
 
      $success= tripal_apollo_rescind_user_permissions($submission_id, $instance_info->id);
 
      if (!$success){
-
        tripal_set_message(t('There was an error removing the apollo rights for %name.', ['%name' => $values['name']]), TRIPAL_ERROR);
        //return before updating status
        return;
      }
-    }
 
     db_update('apollo_user_record')
       ->fields(['status' => $status])
       ->condition('id', $submission_id)
       ->execute();
+    drupal_set_message(t('The apollo request for %name has been successfuly rejected.', ['%name' => $values['name']]), $type = 'status');
+    }
 
+    else {
 
+    db_update('apollo_user_record')
+      ->fields(['status' => $status])
+      ->condition('id', $submission_id)
+      ->execute();
     drupal_set_message(t('The apollo request for %name has been successfuly rejected.', ['%name' => $values['name']]), $type = 'status');
   }
   $form_state['redirect'] = 'admin/tripal/apollo/requests';

--- a/tests/tripal_apollo_api_Test.php
+++ b/tests/tripal_apollo_api_Test.php
@@ -152,8 +152,23 @@ class tripal_apollo_api_Test extends TripalTestCase {
 
     $users = tripal_apollo_get_users($instance->id, $user_info->id);
 
-    $this->assertEmpty($users);
+    //user should exist, but iwthout the groups
 
+$user = $users[0];
+
+$permissions = $user->organismPermissions;
+
+$new_perms = [];
+
+foreach ($permissions as $permission){
+
+  if ($permission->organism == 'yeast'){
+    $new_perms = $permission->permissionArray;
+  }
+
+  $this->assertEmpty($new_perms);
+  
+}
 
   }
 


### PR DESCRIPTION
provide behavior expected in #110 

* rejecting an approved user will remove that organism's permission
* Apollo 1 instances will not be able to reject already approved users (API and the form both have checks)
* test to add user to group, remove them, and confirm permission is gone